### PR TITLE
Fix compilation with Xcode 8.3

### DIFF
--- a/GDPerformanceView-Swift/GDPerformanceMonitoring/GDPerformanceView.swift
+++ b/GDPerformanceView-Swift/GDPerformanceMonitoring/GDPerformanceView.swift
@@ -268,9 +268,15 @@ internal class GDPerformanceView: UIWindow {
         var threadStatistic: UInt32 = 0
         
         kern = withUnsafeMutablePointer(to: &threadList) {
-            $0.withMemoryRebound(to: (thread_act_array_t?.self)!, capacity: 1) {
-                task_threads(mach_task_self_, $0, &threadCount)
-            }
+            #if swift(>=3.1)
+                return $0.withMemoryRebound(to: thread_act_array_t?.self, capacity: 1) {
+                    task_threads(mach_task_self_, $0, &threadCount)
+                }
+            #else
+                return $0.withMemoryRebound(to: (thread_act_array_t?.self)!, capacity: 1) {
+                    task_threads(mach_task_self_, $0, &threadCount)
+                }
+            #endif
         }
         if kern != KERN_SUCCESS {
             return -1


### PR DESCRIPTION
Compiler complains `Cannot force unwrap value of non-optional type 'thread_act_array_t?.Type' (aka 'Optional<UnsafeMutablePointer<UInt32>>.Type')`.

For a simpler explanation, the type of the object is `Optional<T>.Type` which is not optional itself, as opposed to `Optional<T>`