### PR TITLE
fix memory usage not equal Xcode Debug Gauge

### DIFF
--- a/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceСalculator.swift
+++ b/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceСalculator.swift
@@ -127,17 +127,17 @@ private extension PerformanceCalculator {
     }
     
     func memoryUsage() -> MemoryUsage {
-        var taskInfo = mach_task_basic_info()
-        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size)/4
+        var taskInfo = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info>.size) / 4
         let result: kern_return_t = withUnsafeMutablePointer(to: &taskInfo) {
             $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
-                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
             }
         }
         
         var used: UInt64 = 0
         if result == KERN_SUCCESS {
-            used = UInt64(taskInfo.resident_size)
+            used = UInt64(taskInfo.phys_footprint)
         }
         
         let total = ProcessInfo.processInfo.physicalMemory


### PR DESCRIPTION
`resident_size` does not get accurate memory, and the correct way is to use `phys_footprint`, which can be proved from the source codes of WebKit and XNU.[Webkit Source](https://github.com/WebKit/webkit/blob/52bc6f0a96a062cb0eb76e9a81497183dc87c268/Source/WTF/wtf/cocoa/MemoryFootprintCocoa.cpp)