### PR TITLE
Add thermal state monitoring option

### DIFF
--- a/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceMonitor.swift
+++ b/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceMonitor.swift
@@ -65,11 +65,14 @@ public class PerformanceMonitor {
         /// System name with version.
         public static let system = DisplayOptions(rawValue: 1 << 4)
         
+        /// Thermal State (available iOS 11+)
+        public static let thermal = DisplayOptions(rawValue: 1 << 5)
+        
         /// Default dispaly options - CPU usage and FPS, application version with build number and system name with version.
         public static let `default`: DisplayOptions = [.performance, .application, .system]
         
         /// All dispaly options.
-        public static let all: DisplayOptions = [.performance, .memory, .application, .device, .system]
+        public static let all: DisplayOptions = [.performance, .memory, .application, .device, .system, .thermal]
         
         public init(rawValue: Int) {
             self.rawValue = rawValue

--- a/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceView.swift
+++ b/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceView.swift
@@ -147,6 +147,11 @@ internal extension PerformanceView {
             monitoringTexts.append(memory)
         }
         
+        if self.options.contains(.thermal) {
+            let thermal = "Thermal State: \(report.thermalState)"
+            monitoringTexts.append(thermal)
+        }
+        
         if let staticInformation = self.staticInformation {
             monitoringTexts.append(staticInformation)
         }

--- a/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceСalculator.swift
+++ b/GDPerformanceView-Swift/GDPerformanceMonitoring/PerformanceСalculator.swift
@@ -85,7 +85,8 @@ private extension PerformanceCalculator {
             let cpuUsage = self.cpuUsage()
             let fps = self.linkedFramesList.count
             let memoryUsage = self.memoryUsage()
-            self.report(cpuUsage: cpuUsage, fps: fps, memoryUsage: memoryUsage)
+            let thermalState = self.thermalState()
+            self.report(cpuUsage: cpuUsage, fps: fps, memoryUsage: memoryUsage, thermalState: thermalState)
         } else if let start = self.startTimestamp, Date().timeIntervalSince1970 - start >= Constants.accumulationTimeInSeconds {
             self.accumulatedInformationIsEnough = true
         }
@@ -143,6 +144,25 @@ private extension PerformanceCalculator {
         let total = ProcessInfo.processInfo.physicalMemory
         return (used, total)
     }
+    
+    func thermalState() -> String {
+        guard #available(iOS 11, *) else {
+            return "Unknown"
+        }
+        
+        switch ProcessInfo.processInfo.thermalState {
+        case .nominal:
+            return "Nominal"
+        case .fair:
+            return "Fair"
+        case .serious:
+            return "Serious"
+        case .critical:
+            return "Critical"
+        default:
+            return "Unknown"
+        }
+    }
 }
 
 // MARK: Configurations
@@ -158,8 +178,8 @@ private extension PerformanceCalculator {
 // MARK: Support Methods
 
 private extension PerformanceCalculator {
-    func report(cpuUsage: Double, fps: Int, memoryUsage: MemoryUsage) {
-        let performanceReport = (cpuUsage: cpuUsage, fps: fps, memoryUsage: memoryUsage)
+    func report(cpuUsage: Double, fps: Int, memoryUsage: MemoryUsage, thermalState: String) {
+        let performanceReport = (cpuUsage: cpuUsage, fps: fps, memoryUsage: memoryUsage, thermalState: thermalState)
         self.onReport?(performanceReport)
     }
 }

--- a/GDPerformanceView-Swift/GDPerformanceMonitoring/Protocols.swift
+++ b/GDPerformanceView-Swift/GDPerformanceMonitoring/Protocols.swift
@@ -26,7 +26,7 @@ import UIKit
 public typealias MemoryUsage = (used: UInt64, total: UInt64)
 
 /// Performance report tuple. Contains CPU usage in percentages, FPS and memory usage.
-public typealias PerformanceReport = (cpuUsage: Double, fps: Int, memoryUsage: MemoryUsage)
+public typealias PerformanceReport = (cpuUsage: Double, fps: Int, memoryUsage: MemoryUsage, thermalState: String)
 
 /// Performance monitor delegate. Gets called on the main thread.
 public protocol PerformanceMonitorDelegate: class {

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ You can choose from:
 * application - Application version with build number.
 * device - Device model.
 * system - System name with version.
+* thermal - System thermal state
 
 Also you can mix them, but order doesn't matter:
 


### PR DESCRIPTION
I had a need to monitor [Thermal State](https://developer.apple.com/documentation/foundation/nsprocessinfothermalstate) to determine if this was the cause of slowdowns.  Let me know if you think this is useful!

<img width="140" alt="Screen Shot 2021-05-04 at 11 10 39" src="https://user-images.githubusercontent.com/6395840/117025996-62beaf80-acc9-11eb-80b6-2572b43cbd9e.png">
